### PR TITLE
Remove package .namedays

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/events/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/NamedayDatabaseRefresher.java
@@ -19,7 +19,7 @@ import com.alexstyl.specialdates.events.namedays.NamedayCalendar;
 import com.alexstyl.specialdates.events.namedays.NamedayCalendarProvider;
 import com.alexstyl.specialdates.events.namedays.NamedayLocale;
 import com.alexstyl.specialdates.events.namedays.NamedayPreferences;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
 import com.alexstyl.specialdates.util.Utils;
 
 import java.util.ArrayList;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/CharacterNode.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/CharacterNode.java
@@ -1,4 +1,4 @@
-package com.alexstyl.specialdates.namedays;
+package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.gsc.Index;
 import com.alexstyl.specialdates.events.DayDate;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/Dates.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/Dates.java
@@ -1,4 +1,4 @@
-package com.alexstyl.specialdates.namedays;
+package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/GreekNamedays.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/GreekNamedays.java
@@ -1,7 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 import com.novoda.notils.exception.DeveloperError;
 
 import java.util.ArrayList;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/GreekSpecialNamedaysStrategy.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/GreekSpecialNamedaysStrategy.java
@@ -1,7 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 
 import java.util.ArrayList;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NameCelebrations.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NameCelebrations.java
@@ -1,4 +1,4 @@
-package com.alexstyl.specialdates.namedays;
+package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayBundle.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayBundle.java
@@ -1,8 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
-import com.alexstyl.specialdates.namedays.Node;
 
 import java.util.ArrayList;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayCalendar.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayCalendar.java
@@ -1,8 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.Dates;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayJSONParser.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayJSONParser.java
@@ -2,9 +2,6 @@ package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.ErrorTracker;
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.CharacterNode;
-import com.alexstyl.specialdates.namedays.Node;
-import com.alexstyl.specialdates.namedays.SoundNode;
 import com.novoda.notils.exception.DeveloperError;
 
 import org.joda.time.IllegalFieldValueException;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NoSpecialNamedaysStrategy.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NoSpecialNamedaysStrategy.java
@@ -1,7 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 
 import java.util.ArrayList;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/Node.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/Node.java
@@ -1,4 +1,4 @@
-package com.alexstyl.specialdates.namedays;
+package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/RomanianNamedays.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/RomanianNamedays.java
@@ -1,8 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.CharacterNode;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/RomanianSpecialNamedaysStrategy.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/RomanianSpecialNamedaysStrategy.java
@@ -1,7 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/SoundNode.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/SoundNode.java
@@ -1,4 +1,4 @@
-package com.alexstyl.specialdates.namedays;
+package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.gsc.Index;
 import com.alexstyl.gsc.Sound;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/SpecialGreekNamedaysCalculator.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/SpecialGreekNamedaysCalculator.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import com.alexstyl.specialdates.MementoApp;
 import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.Node;
-import com.alexstyl.specialdates.namedays.SoundNode;
 
 import java.util.Calendar;
 import java.util.List;

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/SpecialNamedaysStrategy.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/SpecialNamedaysStrategy.java
@@ -1,7 +1,6 @@
 package com.alexstyl.specialdates.events.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
 
 import java.util.ArrayList;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/search/DeviceSearchFragment.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/search/DeviceSearchFragment.java
@@ -24,7 +24,7 @@ import com.alexstyl.specialdates.contact.Contact;
 import com.alexstyl.specialdates.datedetails.DateDetailsActivity;
 import com.alexstyl.specialdates.events.DayDate;
 import com.alexstyl.specialdates.events.namedays.NamedayPreferences;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
 import com.alexstyl.specialdates.ui.base.MementoFragment;
 import com.alexstyl.specialdates.ui.widget.SpacesItemDecoration;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/search/NamedayCard.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/search/NamedayCard.java
@@ -1,7 +1,7 @@
 package com.alexstyl.specialdates.search;
 
 import com.alexstyl.specialdates.events.DayDate;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
 
 public class NamedayCard {
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/search/NamedaysLoader.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/search/NamedaysLoader.java
@@ -7,7 +7,7 @@ import com.alexstyl.specialdates.events.namedays.NamedayCalendar;
 import com.alexstyl.specialdates.events.namedays.NamedayCalendarProvider;
 import com.alexstyl.specialdates.events.namedays.NamedayLocale;
 import com.alexstyl.specialdates.events.namedays.NamedayPreferences;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
 import com.alexstyl.specialdates.ui.loader.SimpleAsyncTaskLoader;
 
 public class NamedaysLoader extends SimpleAsyncTaskLoader<NameCelebrations> {

--- a/mobile/src/main/java/com/alexstyl/specialdates/search/SearchResultAdapter.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/search/SearchResultAdapter.java
@@ -14,7 +14,7 @@ import com.alexstyl.specialdates.events.namedays.NamedayCalendarProvider;
 import com.alexstyl.specialdates.events.namedays.NamedayLocale;
 import com.alexstyl.specialdates.events.namedays.NamedayPreferences;
 import com.alexstyl.specialdates.images.ImageLoader;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
 import com.novoda.notils.exception.DeveloperError;
 
 import java.util.ArrayList;

--- a/mobile/src/main/java/com/alexstyl/specialdates/search/SearchResultContactViewHolder.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/search/SearchResultContactViewHolder.java
@@ -14,7 +14,7 @@ import com.alexstyl.specialdates.date.DateFormatUtils;
 import com.alexstyl.specialdates.events.DayDate;
 import com.alexstyl.specialdates.events.namedays.NamedayCalendar;
 import com.alexstyl.specialdates.images.ImageLoader;
-import com.alexstyl.specialdates.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
 import com.alexstyl.specialdates.ui.widget.ColorImageView;
 
 class SearchResultContactViewHolder extends RecyclerView.ViewHolder {

--- a/mobile/src/test/java/com/alexstyl/specialdates/namedays/CharacterNodeTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/namedays/CharacterNodeTest.java
@@ -1,5 +1,8 @@
 package com.alexstyl.specialdates.namedays;
 
+import com.alexstyl.specialdates.events.namedays.CharacterNode;
+import com.alexstyl.specialdates.events.namedays.Node;
+
 public class CharacterNodeTest extends NodeTest {
 
     @Override

--- a/mobile/src/test/java/com/alexstyl/specialdates/namedays/NodeTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/namedays/NodeTest.java
@@ -1,6 +1,8 @@
 package com.alexstyl.specialdates.namedays;
 
 import com.alexstyl.specialdates.events.DayDate;
+import com.alexstyl.specialdates.events.namedays.NameCelebrations;
+import com.alexstyl.specialdates.events.namedays.Node;
 
 import org.junit.Test;
 

--- a/mobile/src/test/java/com/alexstyl/specialdates/namedays/SoundNodeTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/namedays/SoundNodeTest.java
@@ -1,5 +1,8 @@
 package com.alexstyl.specialdates.namedays;
 
+import com.alexstyl.specialdates.events.namedays.Node;
+import com.alexstyl.specialdates.events.namedays.SoundNode;
+
 public class SoundNodeTest extends NodeTest {
 
     @Override


### PR DESCRIPTION
#### Description

Currently there are two places were nameday logic exist: `.namedays` and `.events.namedays`. This PR removes the `.namedays` package and moves all classes to the later. 

##### Test(s) added

nope. Just moving some classes