### PR TITLE
Fix NPE crash on NamedayDatabaseRefresher#loadSpecialNamedays()

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/events/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/NamedayDatabaseRefresher.java
@@ -129,7 +129,6 @@ class NamedayDatabaseRefresher {
     private List<ContactEvent> loadSpecialNamedays() {
         List<ContactEvent> namedayEvents = new ArrayList<>();
         Cursor cursor = DeviceContactsQuery.query(contentResolver);
-
         if (isInvalidCursor(cursor)) {
             return namedayEvents;
         }

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/NamedayDatabaseRefresher.java
@@ -77,6 +77,9 @@ class NamedayDatabaseRefresher {
     private List<ContactEvent> loadDeviceStaticNamedays() {
         List<ContactEvent> namedayEvents = new ArrayList<>();
         Cursor cursor = DeviceContactsQuery.query(contentResolver);
+        if (isInvalidCursor(cursor)) {
+            return namedayEvents;
+        }
 
         Set<Long> contactIDs = new HashSet<>();
 
@@ -127,6 +130,10 @@ class NamedayDatabaseRefresher {
         List<ContactEvent> namedayEvents = new ArrayList<>();
         Cursor cursor = DeviceContactsQuery.query(contentResolver);
 
+        if (isInvalidCursor(cursor)) {
+            return namedayEvents;
+        }
+
         Set<Long> contactIDs = new HashSet<>();
 
         while (cursor.moveToNext()) {
@@ -162,6 +169,10 @@ class NamedayDatabaseRefresher {
 
         cursor.close();
         return namedayEvents;
+    }
+
+    private boolean isInvalidCursor(Cursor cursor) {
+        return cursor == null;
     }
 
     private String getDisplayName(Cursor cursor) {


### PR DESCRIPTION
#### Description

This PR fixes the following crash taken from Crashlytics:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'boolean android.database.Cursor.moveToNext()' on a null object reference
       at com.alexstyl.specialdates.events.NamedayDatabaseRefresher.loadSpecialNamedays(NamedayDatabaseRefresher.java:132)
       at com.alexstyl.specialdates.events.NamedayDatabaseRefresher.initialiseNamedaysIfEnabled(NamedayDatabaseRefresher.java:73)
       at com.alexstyl.specialdates.events.NamedayDatabaseRefresher.refreshNamedays(NamedayDatabaseRefresher.java:65)
       at com.alexstyl.specialdates.events.PeopleEventsUpdater.updateEventsIfSettingsChanged(PeopleEventsUpdater.java:64)
       at com.alexstyl.specialdates.events.PeopleEventsUpdater.updateEventsIfNeeded(PeopleEventsUpdater.java:45)
       at com.alexstyl.specialdates.events.PeopleEventsContentProvider.refreshEventsIfNeeded(PeopleEventsContentProvider.java:146)
       at com.alexstyl.specialdates.events.PeopleEventsContentProvider.query(PeopleEventsContentProvider.java:48)
       at android.content.ContentProvider.query(ContentProvider.java:978)
       at android.content.ContentProvider$Transport.query(ContentProvider.java:213)
       at android.content.ContentResolver.query(ContentResolver.java:502)
       at android.content.ContentResolver.query(ContentResolver.java:446)
       at com.alexstyl.specialdates.service.PeopleEventsProvider.getCelebrationDateFor(PeopleEventsProvider.java:55)
       at com.alexstyl.specialdates.service.DailyReminderIntentService.onHandleIntent(DailyReminderIntentService.java:63)
       at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:65)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.os.HandlerThread.run(HandlerThread.java:61)
```
