### PR TITLE
Replace InitMock with Runners

### DIFF
--- a/mobile/src/test/java/com/alexstyl/specialdates/events/bankholidays/BankHolidayRepositoryTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/events/bankholidays/BankHolidayRepositoryTest.java
@@ -5,14 +5,14 @@ import com.alexstyl.specialdates.events.namedays.EasterCalculator;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class BankHolidayRepositoryTest {
 
     private static final DayDate GREEK_INDEPENDENCE_DAY = DayDate.newInstance(25, DayDate.MARCH, 1990);
@@ -23,7 +23,6 @@ public class BankHolidayRepositoryTest {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
         repository = new BankHolidayRepository(calculator);
         when(calculator.calculateEasterForYear(1990)).thenReturn(DayDate.newInstance(1, 1, 1990));
         when(calculator.calculateEasterForYear(1991)).thenReturn(DayDate.newInstance(1, 1, 1991));

--- a/mobile/src/test/java/com/alexstyl/specialdates/upcoming/MonthTitleSetterTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/upcoming/MonthTitleSetterTest.java
@@ -4,12 +4,13 @@ import android.app.Activity;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
-
+@RunWith(MockitoJUnitRunner.class)
 public class MonthTitleSetterTest {
 
     @Mock
@@ -19,11 +20,9 @@ public class MonthTitleSetterTest {
 
     @Before
     public void setup() {
-        initMocks(this);
         MonthLabels monthLabels = new MonthLabels(new String[]{"1", "2", "3", "4", "5", "6"});
         monthTitleSetter = new MonthTitleSetter(mockActivity, monthLabels);
     }
-
 
     @Test
     public void givenTheIndexOfASpecificMonth_whenUpdatingMonth_thenTheTitleIsProperlySet() {

--- a/mobile/src/test/java/com/alexstyl/specialdates/upcoming/NamedaySettingsMonitorTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/upcoming/NamedaySettingsMonitorTest.java
@@ -5,12 +5,14 @@ import com.alexstyl.specialdates.events.namedays.NamedayPreferences;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class NamedaySettingsMonitorTest {
 
     private NamedaySettingsMonitor monitor;
@@ -25,7 +27,6 @@ public class NamedaySettingsMonitorTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
         initialiseMonitor();
     }
 


### PR DESCRIPTION
#### Description

Use `@RunWith(MockitoJUnitRunner.class)` in order to instantiate mocks in tests.

##### Test(s) added

no. Just updated current ones