### PR TITLE
Fail safely instead of throwing exception while creating events

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/events/BirthdayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/BirthdayDatabaseRefresher.java
@@ -35,7 +35,7 @@ class BirthdayDatabaseRefresher {
     static BirthdayDatabaseRefresher newInstance(Context context) {
         ContentResolver cr = context.getContentResolver();
         DateParser dateParser = new DateParser();
-        PeopleEventsPersister persister = PeopleEventsPersister.newInstance(new EventSQLiteOpenHelper(context));
+        PeopleEventsPersister persister = new PeopleEventsPersister(new EventSQLiteOpenHelper(context));
         BirthdayContentValuesMarshaller marshaller = new BirthdayContentValuesMarshaller();
         return new BirthdayDatabaseRefresher(cr, dateParser, persister, marshaller);
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/BirthdayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/BirthdayDatabaseRefresher.java
@@ -20,12 +20,15 @@ import com.alexstyl.specialdates.date.DayDate;
 import com.alexstyl.specialdates.events.database.EventSQLiteOpenHelper;
 import com.alexstyl.specialdates.util.DateParser;
 import com.alexstyl.specialdates.util.Utils;
-import com.novoda.notils.exception.DeveloperError;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 class BirthdayDatabaseRefresher {
+
+    @SuppressWarnings("unchecked")
+    private static final List<Contact> NO_CONTACTS = Collections.EMPTY_LIST;
 
     private final ContentResolver contentResolver;
     private final DateParser dateParser;
@@ -60,7 +63,7 @@ class BirthdayDatabaseRefresher {
     private List<Contact> loadBirtdaysFromDisk() {
         Cursor cursor = Query.query(contentResolver);
         if (isInvalid(cursor)) {
-            throw new DeveloperError("Cursor was invalid");
+            return NO_CONTACTS;
         }
         List<Contact> contacts = new ArrayList<>();
         try {

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/PeopleEventsPersister.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/PeopleEventsPersister.java
@@ -13,10 +13,6 @@ public class PeopleEventsPersister {
 
     private final EventSQLiteOpenHelper helper;
 
-    public static PeopleEventsPersister newInstance(EventSQLiteOpenHelper helper) {
-        return new PeopleEventsPersister(helper);
-    }
-
     public PeopleEventsPersister(EventSQLiteOpenHelper helper) {
         this.helper = helper;
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/PeopleEventsUpdater.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/PeopleEventsUpdater.java
@@ -40,7 +40,7 @@ class PeopleEventsUpdater {
         boolean isFirstRun = isFirstTimeRunning();
         if (isFirstRun) {
             birthdayDatabaseRefresher.refreshBirthdays();
-            namedayDatabaseRefresher.refreshNamedays();
+            namedayDatabaseRefresher.refreshNamedaysIfEnabled();
             eventPreferences.markEventsAsInitialised();
         } else {
             updateEventsIfSettingsChanged();
@@ -62,7 +62,7 @@ class PeopleEventsUpdater {
             birthdayDatabaseRefresher.refreshBirthdays();
         }
         if (wereContactsUpdated || wereNamedaysSettingsUpdated) {
-            namedayDatabaseRefresher.refreshNamedays();
+            namedayDatabaseRefresher.refreshNamedaysIfEnabled();
         }
         resetMonitorFlags();
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
@@ -60,14 +60,14 @@ public class NamedayDatabaseRefresher {
         this.eventMarshaller = eventMarshaller;
     }
 
-    public void refreshNamedays() {
+    public void refreshNamedaysIfEnabled() {
         perister.deleteAllNamedays();
         if (namedaysEnabled()) {
-            initialiseNamedaysIfEnabled();
+            initialiseNamedays();
         }
     }
 
-    private void initialiseNamedaysIfEnabled() {
+    private void initialiseNamedays() {
         List<ContactEvent> namedays = loadDeviceStaticNamedays();
         storeNamedaysToDisk(namedays);
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
@@ -43,7 +43,7 @@ public class NamedayDatabaseRefresher {
         NamedayPreferences namedayPreferences = NamedayPreferences.newInstance(context);
         ContactProvider contactProvider = ContactProvider.get(context);
         ContentValuesMarshaller marshaller = new ContentValuesMarshaller();
-        PeopleEventsPersister persister = PeopleEventsPersister.newInstance(new EventSQLiteOpenHelper(context));
+        PeopleEventsPersister persister = new PeopleEventsPersister(new EventSQLiteOpenHelper(context));
         return new NamedayDatabaseRefresher(contentResolver, namedayProvider, namedayPreferences, persister, contactProvider, marshaller);
     }
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
@@ -25,6 +25,7 @@ import com.alexstyl.specialdates.events.namedays.calendar.NamedayCalendarProvide
 import com.alexstyl.specialdates.util.Utils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +33,8 @@ import java.util.Set;
 public class NamedayDatabaseRefresher {
 
     private static final Optional<Contact> NO_CONTACT = Optional.absent();
+    @SuppressWarnings("unchecked")
+    private static final List<ContactEvent> NO_EVENTS = Collections.EMPTY_LIST;
 
     private final ContentResolver contentResolver;
     private final ContactProvider contactProvider;
@@ -79,12 +82,12 @@ public class NamedayDatabaseRefresher {
     }
 
     private List<ContactEvent> loadDeviceStaticNamedays() {
-        List<ContactEvent> namedayEvents = new ArrayList<>();
         Cursor cursor = DeviceContactsQuery.query(contentResolver);
         if (isInvalidCursor(cursor)) {
-            return namedayEvents;
+            return NO_EVENTS;
         }
 
+        List<ContactEvent> namedayEvents = new ArrayList<>();
         Set<Long> contactIDs = new HashSet<>();
 
         while (cursor.moveToNext()) {
@@ -125,12 +128,12 @@ public class NamedayDatabaseRefresher {
     }
 
     private List<ContactEvent> loadSpecialNamedays() {
-        List<ContactEvent> namedayEvents = new ArrayList<>();
         Cursor cursor = DeviceContactsQuery.query(contentResolver);
         if (isInvalidCursor(cursor)) {
-            return namedayEvents;
+            return NO_EVENTS;
         }
 
+        List<ContactEvent> namedayEvents = new ArrayList<>();
         Set<Long> contactIDs = new HashSet<>();
 
         while (cursor.moveToNext()) {


### PR DESCRIPTION
#### Description

Every time we are trying to create an event for contact that does not exist in the `NamedayDatabaseRefresher` we throw an Exception when we do. This means that if we have 99 valid events but one without a contact, the whole process will fail. In this PR we are making sure that we are just ignoring that contact instead of throwing an exception. 

##### Test(s) added

no. `NamedayDatabaseRefresher` is a class hard to Test. I opened an issue (https://github.com/alexstyl/Memento-Namedays/issues/11) in order to fix this in the future.
