### PR TITLE
Fix for: Contact does not appear when creating birthday

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/date/ContactEvent.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/date/ContactEvent.java
@@ -12,11 +12,7 @@ public class ContactEvent {
     private final Contact contact;
     private final EventType eventType;
 
-    public static ContactEvent newInstance(EventType eventType, DayDate date, Contact contact) {
-        return new ContactEvent(eventType, date, contact);
-    }
-
-    ContactEvent(EventType eventType, DayDate date, Contact contact) {
+    public ContactEvent(EventType eventType, DayDate date, Contact contact) {
         this.eventType = eventType;
         this.date = date;
         this.contact = contact;

--- a/mobile/src/main/java/com/alexstyl/specialdates/datedetails/DateDetailsLoader.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/datedetails/DateDetailsLoader.java
@@ -69,7 +69,7 @@ public class DateDetailsLoader extends SimpleAsyncTaskLoader<List<ContactEvent>>
             try {
                 Contact contact = buildContactFrom(cursor);
                 EventType eventType = PeopleEvents.getEventType(cursor);
-                ContactEvent contactEvent = ContactEvent.newInstance(eventType, date, contact);
+                ContactEvent contactEvent = new ContactEvent(eventType, date, contact);
 
                 result.add(contactEvent);
             } catch (ContactNotFoundException e) {

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/NamedayDatabaseRefresher.java
@@ -116,7 +116,7 @@ public class NamedayDatabaseRefresher {
                     if (namedays.contains(nameday)) {
                         continue;
                     }
-                    ContactEvent event = ContactEvent.newInstance(EventType.NAMEDAY, date, contact.get());
+                    ContactEvent event = new ContactEvent(EventType.NAMEDAY, date, contact.get());
                     namedayEvents.add(event);
                     namedays.add(nameday);
                 }
@@ -160,7 +160,7 @@ public class NamedayDatabaseRefresher {
                 int namedaysCount = nameDays.size();
                 for (int i = 0; i < namedaysCount; i++) {
                     DayDate date = nameDays.getDate(i);
-                    ContactEvent nameday = ContactEvent.newInstance(EventType.NAMEDAY, date, contact.get());
+                    ContactEvent nameday = new ContactEvent(EventType.NAMEDAY, date, contact.get());
                     namedayEvents.add(nameday);
                 }
             }

--- a/mobile/src/main/java/com/alexstyl/specialdates/service/PeopleEventsProvider.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/service/PeopleEventsProvider.java
@@ -69,7 +69,7 @@ public class PeopleEventsProvider {
                 Contact contact = contactProvider.getOrCreateContact(contactId);
                 EventType eventType = PeopleEventsContract.PeopleEvents.getEventType(cursor);
 
-                ContactEvent event = ContactEvent.newInstance(eventType, date, contact);
+                ContactEvent event = new ContactEvent(eventType, date, contact);
                 contactEvents.add(event);
             } catch (Exception e) {
                 ErrorTracker.track(e);
@@ -193,7 +193,7 @@ public class PeopleEventsProvider {
         DayDate date = PeopleEventsContract.PeopleEvents.getDateFrom(cursor);
         EventType eventType = PeopleEventsContract.PeopleEvents.getEventType(cursor);
 
-        return ContactEvent.newInstance(eventType, date, contact);
+        return new ContactEvent(eventType, date, contact);
     }
 
     private void throwIfInvalid(Cursor cursor) {

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingDatesBuilder.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingDatesBuilder.java
@@ -78,14 +78,17 @@ public class UpcomingDatesBuilder {
         return this;
     }
 
+    private static final List<CelebrationDate> NO_CELEBRATIONS = Collections.emptyList();
+
     public List<CelebrationDate> build() {
-        List<CelebrationDate> celebrationDates = new ArrayList<>();
         if (noEventsArePresent()) {
-            return celebrationDates;
+            return NO_CELEBRATIONS;
         }
+
+        List<CelebrationDate> celebrationDates = new ArrayList<>();
         DayDate indexDate = earliestDate.get();
         DayDate lastDate = latestDate.get();
-        while (indexDate.isBefore(lastDate)) {
+        while (indexDate.compareTo(lastDate) <= 0) {
             List<ContactEvent> contactEvent = contactEvents.get(indexDate);
             if (contactEvent == null) {
                 contactEvent = NO_CONTACT_EVENTS;

--- a/mobile/src/test/java/com/alexstyl/specialdates/TestContact.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/TestContact.java
@@ -1,16 +1,15 @@
-package com.alexstyl.specialdates.events;
+package com.alexstyl.specialdates;
 
 import android.content.Context;
 import android.net.Uri;
 import android.view.View;
 
-import com.alexstyl.specialdates.DisplayName;
 import com.alexstyl.specialdates.contact.Contact;
 import com.alexstyl.specialdates.contact.actions.LabeledAction;
 
 import java.util.List;
 
-class TestContact extends Contact {
+public class TestContact extends Contact {
 
     public TestContact(long id, DisplayName displayName) {
         super(id, displayName);

--- a/mobile/src/test/java/com/alexstyl/specialdates/events/ContactEventsTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/events/ContactEventsTest.java
@@ -1,6 +1,7 @@
 package com.alexstyl.specialdates.events;
 
 import com.alexstyl.specialdates.DisplayName;
+import com.alexstyl.specialdates.TestContact;
 import com.alexstyl.specialdates.contact.Contact;
 import com.alexstyl.specialdates.date.ContactEvent;
 import com.alexstyl.specialdates.date.DayDate;

--- a/mobile/src/test/java/com/alexstyl/specialdates/events/ContactEventsTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/events/ContactEventsTest.java
@@ -16,10 +16,10 @@ public class ContactEventsTest {
 
     private final List<ContactEvent> ANY_CONTACTS = new ArrayList<>();
     private final TestContact CONTACT_ONE = new TestContact(1, DisplayName.from("Alex Styl"));
-    private final ContactEvent EVENT_ONE = ContactEvent.newInstance(EventType.BIRTHDAY, DayDate.newInstance(1, 1, 1990), CONTACT_ONE);
+    private final ContactEvent EVENT_ONE = new ContactEvent(EventType.BIRTHDAY, DayDate.newInstance(1, 1, 1990), CONTACT_ONE);
 
     private final TestContact CONTACT_TWO = new TestContact(2, DisplayName.from("George Peterson"));
-    private final ContactEvent EVENT_TWO = ContactEvent.newInstance(EventType.BIRTHDAY, DayDate.newInstance(1, 1, 1970), CONTACT_TWO);
+    private final ContactEvent EVENT_TWO = new ContactEvent(EventType.BIRTHDAY, DayDate.newInstance(1, 1, 1970), CONTACT_TWO);
 
     @Test
     public void testTheSameDateIsReturned() throws Exception {

--- a/mobile/src/test/java/com/alexstyl/specialdates/upcoming/UpcomingDatesBuilderTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/upcoming/UpcomingDatesBuilderTest.java
@@ -1,11 +1,15 @@
 package com.alexstyl.specialdates.upcoming;
 
+import android.support.annotation.NonNull;
+
 import com.alexstyl.specialdates.DisplayName;
 import com.alexstyl.specialdates.date.CelebrationDate;
 import com.alexstyl.specialdates.date.ContactEvent;
 import com.alexstyl.specialdates.date.DayDate;
 import com.alexstyl.specialdates.events.EventType;
 import com.alexstyl.specialdates.TestContact;
+import com.alexstyl.specialdates.events.bankholidays.BankHoliday;
+import com.alexstyl.specialdates.events.namedays.NamesInADate;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,6 +26,7 @@ public class UpcomingDatesBuilderTest {
 
     private static final DayDate FEBRUARY_1st = DayDate.newInstance(1, DayDate.FEBRUARY, 1990);
     private static final DayDate FEBRUARY_3rd = DayDate.newInstance(3, DayDate.FEBRUARY, 1990);
+    private static final DayDate MARCH_5th = DayDate.newInstance(5, DayDate.MARCH, 1990);
 
     @Test
     public void givenASingleContactEvent_thenOneCelebrationDateIsCreated() {
@@ -47,7 +52,7 @@ public class UpcomingDatesBuilderTest {
     }
 
     @Test
-    public void givenTwoContactEventsOnSameDate_thenOneCelebrationDateIsCreated() throws Exception {
+    public void givenTwoContactEventsOnSameDate_thenOneCelebrationDateIsCreated() {
         List<ContactEvent> contactEventsList = Arrays.asList(
                 aContactEventOn(FEBRUARY_1st),
                 aContactEventOn(FEBRUARY_1st)
@@ -61,7 +66,7 @@ public class UpcomingDatesBuilderTest {
     }
 
     @Test
-    public void givenTwoContactEventsOnDifferentDate_thenTwoCelebrationDateAreCreated() throws Exception {
+    public void givenTwoContactEventsOnDifferentDate_thenTwoCelebrationDateAreCreated() {
         List<ContactEvent> contactEventsList = Arrays.asList(
                 aContactEventOn(FEBRUARY_1st),
                 aContactEventOn(FEBRUARY_3rd)
@@ -72,6 +77,36 @@ public class UpcomingDatesBuilderTest {
                 .build();
 
         assertThat(dates.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void givenABankHoliday_thenACelebrationDateIsCreated() {
+        List<BankHoliday> bankHolidays = Collections.singletonList(aBankHoliday());
+        List<CelebrationDate> dates = new UpcomingDatesBuilder()
+                .withBankHolidays(bankHolidays)
+                .build();
+
+        assertThat(dates.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void givenEventsOnDifferentEvents_thenACelebrationDatesForEachOneAreCreated() {
+        List<CelebrationDate> dates = new UpcomingDatesBuilder()
+                .withContactEvents(Collections.singletonList(aContactEventOn(FEBRUARY_1st)))
+                .withBankHolidays(Collections.singletonList(aBankHolidayOn(FEBRUARY_3rd)))
+                .withNamedays(Collections.singletonList(new NamesInADate(MARCH_5th, Collections.singletonList("Name"))))
+                .build();
+
+        assertThat(dates.size()).isEqualTo(3);
+    }
+
+    private BankHoliday aBankHolidayOn(DayDate date) {
+        return new BankHoliday("A bank holiday", date);
+    }
+
+    @NonNull
+    private BankHoliday aBankHoliday() {
+        return new BankHoliday("A bank holiday", DayDate.newInstance(1, 1, 1990));
     }
 
     private static ContactEvent aContactEvent() {

--- a/mobile/src/test/java/com/alexstyl/specialdates/upcoming/UpcomingDatesBuilderTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/upcoming/UpcomingDatesBuilderTest.java
@@ -1,0 +1,86 @@
+package com.alexstyl.specialdates.upcoming;
+
+import com.alexstyl.specialdates.DisplayName;
+import com.alexstyl.specialdates.date.CelebrationDate;
+import com.alexstyl.specialdates.date.ContactEvent;
+import com.alexstyl.specialdates.date.DayDate;
+import com.alexstyl.specialdates.events.EventType;
+import com.alexstyl.specialdates.TestContact;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpcomingDatesBuilderTest {
+
+    private static final DayDate FEBRUARY_1st = DayDate.newInstance(1, DayDate.FEBRUARY, 1990);
+    private static final DayDate FEBRUARY_3rd = DayDate.newInstance(3, DayDate.FEBRUARY, 1990);
+
+    @Test
+    public void givenASingleContactEvent_thenOneCelebrationDateIsCreated() {
+        List<ContactEvent> contactEvents = Collections.singletonList(aContactEvent());
+
+        List<CelebrationDate> dates = new UpcomingDatesBuilder()
+                .withContactEvents(contactEvents)
+                .build();
+
+        assertThat(dates.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void givenASingleContactEvent_thenTheCelebrationDateContainsTheContactEvent() {
+        List<ContactEvent> contactEvents = Collections.singletonList(aContactEvent());
+
+        List<CelebrationDate> dates = new UpcomingDatesBuilder()
+                .withContactEvents(contactEvents)
+                .build();
+
+        ContactEvent celebrationDateEvent = dates.get(0).getContactEvents().getEvent(0);
+        assertThat(celebrationDateEvent).isEqualTo(contactEvents.get(0));
+    }
+
+    @Test
+    public void givenTwoContactEventsOnSameDate_thenOneCelebrationDateIsCreated() throws Exception {
+        List<ContactEvent> contactEventsList = Arrays.asList(
+                aContactEventOn(FEBRUARY_1st),
+                aContactEventOn(FEBRUARY_1st)
+        );
+
+        List<CelebrationDate> dates = new UpcomingDatesBuilder()
+                .withContactEvents(contactEventsList)
+                .build();
+
+        assertThat(dates.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void givenTwoContactEventsOnDifferentDate_thenTwoCelebrationDateAreCreated() throws Exception {
+        List<ContactEvent> contactEventsList = Arrays.asList(
+                aContactEventOn(FEBRUARY_1st),
+                aContactEventOn(FEBRUARY_3rd)
+        );
+
+        List<CelebrationDate> dates = new UpcomingDatesBuilder()
+                .withContactEvents(contactEventsList)
+                .build();
+
+        assertThat(dates.size()).isEqualTo(2);
+    }
+
+    private static ContactEvent aContactEvent() {
+        return aContactEventOn(DayDate.newInstance(1, 1, 1990));
+    }
+
+    private static ContactEvent aContactEventOn(DayDate date) {
+        TestContact contact = new TestContact(1, DisplayName.NO_NAME);
+        return new ContactEvent(EventType.BIRTHDAY, date, contact);
+    }
+
+}


### PR DESCRIPTION
#### Description

While creating contact events through the `UpcomingDatesBuilder` some events would not be created.  This was caused due to some internal check of the builder. The builder would create events that have dates between the earliest and the latest event of all events. This would make the all events on the last date to be lost, as it would not check events with date equals to the latest event date.

This PR solves the issue reported here: Contact does not appear when creating birthday #3 


##### Test(s) added

yes. Around the `UpcomingDatesBuilder` class

##### Screenshots
![bug_fixed](https://cloud.githubusercontent.com/assets/1665273/18227872/d396713a-722b-11e6-9bcd-a0bea6834cef.gif)
