### PR TITLE
Show/Hide year for Birthdays with/without year specified

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
@@ -109,11 +109,13 @@ public class BirthdayDatePicker extends LinearLayout {
             dayPicker.setValue(dateToDisplay.getDayOfMonth());
             monthPicker.setValue(dateToDisplay.getMonth());
             yearPicker.setValue(dateToDisplay.getYear());
+            yearPicker.setVisibility(VISIBLE);
             includesYearCheckbox.setChecked(true);
         } else {
             dayPicker.setValue(dateToDisplay.getDayOfMonth());
             monthPicker.setValue(dateToDisplay.getMonth());
             yearPicker.setValue(DayDate.today().getYear());
+            yearPicker.setVisibility(GONE);
             includesYearCheckbox.setChecked(false);
         }
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/contact/Birthday.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/contact/Birthday.java
@@ -41,7 +41,7 @@ public class Birthday {
 
     @Override
     public String toString() {
-        return DateDisplayStringCreator.getInstance().stringOf(date);
+        return DateDisplayStringCreator.getInstance().fullyFormattedBirthday(this);
     }
 
     @Override


### PR DESCRIPTION
#### Description

This PR takes into consideration whether the passing birthday has a specified year or not, and shows/hide the year picker in the Birthday Picker dialog.

This PR fixes the issue described here: Select Date Dialog #7


##### Test(s) added

no. Android related components updated

##### Screenshots
![checkbox_fix](https://cloud.githubusercontent.com/assets/1665273/18228047/2b13e09a-7232-11e6-986c-fc7b5aeb1840.gif)

