### PR TITLE
Aging issues

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
@@ -125,9 +125,9 @@ public class BirthdayDatePicker extends LinearLayout {
         int month = getMonth();
         if (isDisplayingYear()) {
             int year = getYear();
-            return new Birthday(dayOfMonth, month, year);
+            return Birthday.on(dayOfMonth, month, year);
         } else {
-            return new Birthday(dayOfMonth, month);
+            return Birthday.on(dayOfMonth, month);
         }
     }
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/contact/Birthday.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/contact/Birthday.java
@@ -2,6 +2,7 @@ package com.alexstyl.specialdates.contact;
 
 import com.alexstyl.specialdates.Optional;
 import com.alexstyl.specialdates.date.AnnualEvent;
+import com.alexstyl.specialdates.date.Date;
 import com.alexstyl.specialdates.date.DateDisplayStringCreator;
 import com.alexstyl.specialdates.date.DayDate;
 
@@ -11,16 +12,27 @@ public class Birthday implements ShortDate {
     private final Optional<Integer> yearOfBirth;
 
     public static Birthday on(DayDate date) {
-        return new Birthday(date.getDayOfMonth(), date.getMonth(), date.getYear());
+        if (date.getYear() == Date.NO_YEAR) {
+            return new Birthday(date.getDayOfMonth(), date.getMonth(), Optional.<Integer>absent());
+        } else {
+            return new Birthday(date.getDayOfMonth(), date.getMonth(), new Optional<>(date.getYear()));
+        }
     }
 
-    public Birthday(int day, int month) {
-        this(day, month, DayDate.NO_YEAR);
+    public static Birthday on(int dayOfMonth, int month) {
+        return new Birthday(dayOfMonth, month, Optional.<Integer>absent());
     }
 
-    public Birthday(int dayOfMonth, int month, int year) {
+    public static Birthday on(int dayOfMonth, int month, int year) {
+        if (year <= Date.NO_YEAR) {
+            throw new IllegalArgumentException("A birthday cannot have negative year");
+        }
+        return new Birthday(dayOfMonth, month, new Optional<>(year));
+    }
+
+    private Birthday(int dayOfMonth, int month, Optional<Integer> year) {
         this.date = new AnnualEvent(dayOfMonth, month);
-        this.yearOfBirth = new Optional<>(year);
+        this.yearOfBirth = year;
     }
 
     public int getDayOfMonth() {

--- a/mobile/src/main/java/com/alexstyl/specialdates/contact/DeviceContactFactory.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/contact/DeviceContactFactory.java
@@ -75,7 +75,7 @@ class DeviceContactFactory {
         String birthday = cursor.getString(ContactsQuery.BIRTHDAY);
         try {
             DayDate parse = dateParser.parse(birthday);
-            return new Birthday(parse.getDayOfMonth(), parse.getMonth(), parse.getYear());
+            return Birthday.on(parse);
         } catch (DateParseException e) {
             ErrorTracker.track(e);
         }

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/BirthdayDatabaseRefresher.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/BirthdayDatabaseRefresher.java
@@ -95,7 +95,7 @@ class BirthdayDatabaseRefresher {
 
     private Birthday birthdayOn(String bday) throws DateParseException {
         DayDate parsedDate = dateParser.parse(bday);
-        return new Birthday(parsedDate.getDayOfMonth(), parsedDate.getMonth(), parsedDate.getYear());
+        return Birthday.on(parsedDate);
     }
 
     private boolean isInvalid(Cursor cursor) {

--- a/mobile/src/test/java/com/alexstyl/specialdates/contact/BirthdayTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/contact/BirthdayTest.java
@@ -11,13 +11,30 @@ public class BirthdayTest {
 
     @Test
     public void shortNameWithYear() {
-        Birthday aBirthday = new Birthday(1, 2, 1990);
+        Birthday aBirthday = Birthday.on(1, 2, 1990);
         assertThat(aBirthday.toShortDate()).isEqualTo("--02-01");
     }
 
     @Test
     public void shortNameWithNoYear() {
-        Birthday aBirthday = new Birthday(1, 2);
+        Birthday aBirthday = Birthday.on(1, 2);
         assertThat(aBirthday.toShortDate()).isEqualTo("--02-01");
+    }
+
+    @Test
+    public void whenNoYearIsPresent_ItDoesNotIncludeYear() {
+        Birthday birthday = Birthday.on(1, 2);
+        assertThat(birthday.includesYear()).isFalse();
+    }
+
+    @Test
+    public void whenYearIsPresent_ItDoesIncludeYear() {
+        Birthday birthday = Birthday.on(1, 2, 1990);
+        assertThat(birthday.includesYear()).isTrue();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenInvalidYearInPassed_thenExceptionIsThrown() {
+        Birthday.on(1, 2, -1);
     }
 }


### PR DESCRIPTION
#### Description

Currently it is possible to create Birthdays that people are born in year `-1` which doesn't make sense. This also causes the UI to display some crazy birthday ages (such as 2016 etc).

This PR hides the constructors of the `Birthday` class and uses factory methods instead. The factory methods throw exceptions if a invalid year is passed. 

##### Test(s) added

yes. Added some more tests around the `Birthday` class