### PR TITLE
Release resources onUnregisterObserver instead of onAbandon

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/datedetails/DateDetailsLoader.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/datedetails/DateDetailsLoader.java
@@ -55,8 +55,8 @@ public class DateDetailsLoader extends SimpleAsyncTaskLoader<List<ContactEvent>>
     }
 
     @Override
-    protected void onAbandon() {
-        super.onAbandon();
+    protected void onUnregisterObserver() {
+        super.onUnregisterObserver();
         contactsObserver.unregister();
     }
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/search/SearchLoader.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/search/SearchLoader.java
@@ -33,8 +33,8 @@ public class SearchLoader extends SimpleAsyncTaskLoader<SearchResults> {
     }
 
     @Override
-    protected void onAbandon() {
-        super.onAbandon();
+    protected void onUnregisterObserver() {
+        super.onUnregisterObserver();
         observer.unregister();
     }
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsLoader.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsLoader.java
@@ -46,8 +46,8 @@ public class UpcomingEventsLoader extends SimpleAsyncTaskLoader<List<Celebration
     }
 
     @Override
-    protected void onAbandon() {
-        super.onAbandon();
+    protected void onUnregisterObserver() {
+        super.onUnregisterObserver();
         contactsObserver.unregister();
     }
 


### PR DESCRIPTION
#### Description

LeakCanary is picking up some memeory leaks narrowing down that `ContactsObserver` was leaking the activity's context it is being used.
```
In com.alexstyl.specialdates:3.8:57.
* com.alexstyl.specialdates.ui.activity.MainActivity has leaked:
…

* GC ROOT android.database.ContentObserver$Transport.mContentObserver
* references com.alexstyl.specialdates.util.ContactsObserver$1.this$0 (anonymous class extends android.database.ContentObserver)
* references com.alexstyl.specialdates.util.ContactsObserver.callback
* references com.alexstyl.specialdates.upcoming.UpcomingEventsLoader$1.this$0 (anonymous class implements com.alexstyl.specialdates.util.ContactsObserver$Callback)
* references com.alexstyl.specialdates.upcoming.UpcomingEventsLoader.peopleEventsProvider
* references com.alexstyl.specialdates.service.PeopleEventsProvider.resolver
…

* references android.app.ContextImpl$ApplicationContentResolver.mContext
* references android.app.ContextImpl.mOuterContext
* leaks com.alexstyl.specialdates.ui.activity.MainActivity instance
```

as it turns out, the problem was not the Observer itself, but it was not being released in each of the Loaders it is being used. In this PR, all resources are released on the `onUnregisterObserver()` instead of `onAbandon()` which might not be called while dismissing the Loader