### PR TITLE
Notification enhancement

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/settings/DailyReminderFragment.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/settings/DailyReminderFragment.java
@@ -16,10 +16,9 @@ import android.view.MenuItem;
 
 import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.analytics.Action;
-import com.alexstyl.specialdates.analytics.Analytics;
 import com.alexstyl.specialdates.analytics.ActionWithParameters;
+import com.alexstyl.specialdates.analytics.Analytics;
 import com.alexstyl.specialdates.analytics.Firebase;
-import com.alexstyl.specialdates.receiver.EventReceiver;
 import com.alexstyl.specialdates.service.DailyReminderIntentService;
 import com.alexstyl.specialdates.ui.widget.TimePreference;
 import com.alexstyl.specialdates.util.Utils;
@@ -53,12 +52,6 @@ public class DailyReminderFragment extends MyPreferenceFragment {
                 ActionWithParameters event = new ActionWithParameters(Action.DAILY_REMINDER, "enabled", isChecked);
                 analytics.trackAction(event);
                 if (isChecked) {
-
-                    // TODO DEBUG
-                    Intent myIntent = new Intent(context, EventReceiver.class);
-                    myIntent.setAction(EventReceiver.ACTION_START_DAILYREMINDER);
-                    context.sendBroadcast(myIntent);
-
                     DailyReminderIntentService.rescheduleAlarm(context);
                 } else {
                     DailyReminderIntentService.cancelAlarm(context);

--- a/mobile/src/main/java/com/alexstyl/specialdates/settings/DailyReminderFragment.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/settings/DailyReminderFragment.java
@@ -19,6 +19,7 @@ import com.alexstyl.specialdates.analytics.Action;
 import com.alexstyl.specialdates.analytics.Analytics;
 import com.alexstyl.specialdates.analytics.ActionWithParameters;
 import com.alexstyl.specialdates.analytics.Firebase;
+import com.alexstyl.specialdates.receiver.EventReceiver;
 import com.alexstyl.specialdates.service.DailyReminderIntentService;
 import com.alexstyl.specialdates.ui.widget.TimePreference;
 import com.alexstyl.specialdates.util.Utils;
@@ -52,6 +53,12 @@ public class DailyReminderFragment extends MyPreferenceFragment {
                 ActionWithParameters event = new ActionWithParameters(Action.DAILY_REMINDER, "enabled", isChecked);
                 analytics.trackAction(event);
                 if (isChecked) {
+
+                    // TODO DEBUG
+                    Intent myIntent = new Intent(context, EventReceiver.class);
+                    myIntent.setAction(EventReceiver.ACTION_START_DAILYREMINDER);
+                    context.sendBroadcast(myIntent);
+
                     DailyReminderIntentService.rescheduleAlarm(context);
                 } else {
                     DailyReminderIntentService.cancelAlarm(context);

--- a/mobile/src/main/java/com/alexstyl/specialdates/util/Notifier.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/util/Notifier.java
@@ -101,6 +101,7 @@ public class Notifier {
                 .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
                 .setAutoCancel(true)
                 .setContentIntent(intent)
+                .setNumber(events.getContactCount())
                 .setColor(context.getResources().getColor(R.color.main_red));
 
         // if event.getContacts() > 1 then use InboxStyle, otherwise the BigTextStyle like here:
@@ -126,7 +127,7 @@ public class Notifier {
                 String lineFormat = context.getString(R.string.age_today);
                 int lineParamStartPos = lineFormat.indexOf("%1$s");
                 if (lineParamStartPos < 0) {
-                    throw new InvalidParameterException("Something's wrong with your string! LINT could have caught that.");
+                    throw new InvalidParameterException();
                 }
                 String lineFormatted = context.getString(R.string.age_today, name, age);
 
@@ -136,6 +137,7 @@ public class Notifier {
             }
 
             builder.setStyle(inboxStyle);
+            builder.setContentText(TextUtils.join(", ", events.getContacts()));
         }
 
         if (supportsPublicNotifications()) {

--- a/mobile/src/main/java/com/alexstyl/specialdates/util/Notifier.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/util/Notifier.java
@@ -109,15 +109,7 @@ public class Notifier {
 
         if (events.size() == 1) {
             ContactEvent event = events.getEvent(0);
-            String msg = "";
-
-            if (EventType.BIRTHDAY.equals(event.getType())) {
-                int age = event.getContact().getBirthday().getAgeOnYear(event.getYear());
-                msg = context.getString(R.string.turns_age, age);
-
-            } else if (EventType.NAMEDAY.equals(event.getType())) {
-                msg = context.getString(R.string.nameday);
-            }
+            String msg = getLabelFor(event);
 
             NotificationCompat.BigTextStyle bigTextStyle = new NotificationCompat.BigTextStyle().bigText(msg);
             bigTextStyle.setBigContentTitle(title);

--- a/mobile/src/main/java/com/alexstyl/specialdates/util/Notifier.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/util/Notifier.java
@@ -23,6 +23,7 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 
 import com.alexstyl.specialdates.R;
+import com.alexstyl.specialdates.contact.Birthday;
 import com.alexstyl.specialdates.contact.Contact;
 import com.alexstyl.specialdates.date.ContactEvent;
 import com.alexstyl.specialdates.date.Date;
@@ -134,17 +135,7 @@ public class Notifier {
                 Contact contact = event.getContact();
                 String name = contact.getDisplayName().toString();
 
-                String lineFormatted = name;
-
-                if (EventType.BIRTHDAY.equals(event.getType())) {
-                    int age = contact.getBirthday().getAgeOnYear(events.getDate().getYear());
-
-                    lineFormatted += "   " + context.getString(R.string.turns_age, age);
-
-                } else if (EventType.NAMEDAY.equals(event.getType())) {
-                    lineFormatted += "   " + context.getString(R.string.nameday);
-
-                }
+                String lineFormatted = name + "   " + getLabelFor(event);
 
                 Spannable sb = new SpannableString(lineFormatted);
                 sb.setSpan(new StyleSpan(Typeface.BOLD), 0, name.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -186,6 +177,27 @@ public class Notifier {
         NotificationManager mngr = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         mngr.notify(NOTIFICATION_ID_DAILY_REMINDER_CONTACTS, notification);
 
+    }
+
+    /**
+     * TODO duplicated from {@link com.alexstyl.specialdates.upcoming.ui.ContactEventView#getLabelFor(ContactEvent)}
+     *
+     * @deprecated
+     */
+    private String getLabelFor(ContactEvent event) {
+        Resources resources = context.getResources();
+
+        EventType eventType = event.getType();
+        if (eventType == EventType.BIRTHDAY) {
+            Birthday birthday = event.getContact().getBirthday();
+            if (birthday.includesYear()) {
+                int age = birthday.getAgeOnYear(event.getYear());
+                if (age > 0) {
+                    return resources.getString(R.string.turns_age, age);
+                }
+            }
+        }
+        return resources.getString(eventType.nameRes());
     }
 
     public static Bitmap getCircleBitmap(Bitmap bitmap) {

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="today_celebrates_one">%1$s</string>
     <string name="today_celebrates_two">%1$s and %2$s</string>
     <string name="today_celebrates_many">%1$s and %2$d others</string>
-    <string name="age_today">%1$s  %2$d today</string>
+    <string name="age_today">%1$s   %2$d today</string>
     <string name="about">About</string>
     <string name="service_dailyreminder">Daily Reminder Service</string>
     <string name="display_namedays">Display Name Days</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="today_celebrates_one">%1$s</string>
     <string name="today_celebrates_two">%1$s and %2$s</string>
     <string name="today_celebrates_many">%1$s and %2$d others</string>
+    <string name="age_today">%1$s  %2$d today</string>
     <string name="about">About</string>
     <string name="service_dailyreminder">Daily Reminder Service</string>
     <string name="display_namedays">Display Name Days</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -19,7 +19,6 @@
     <string name="today_celebrates_one">%1$s</string>
     <string name="today_celebrates_two">%1$s and %2$s</string>
     <string name="today_celebrates_many">%1$s and %2$d others</string>
-    <string name="age_today">%1$s   %2$d today</string>
     <string name="about">About</string>
     <string name="service_dailyreminder">Daily Reminder Service</string>
     <string name="display_namedays">Display Name Days</string>

--- a/secret.gradle
+++ b/secret.gradle
@@ -1,5 +1,4 @@
 ext {
-
     // Replace the existing values with your own unique keys
     crashlyticsKey = "1234567890123456789012345678901234567890"
     androidVendingKey = "Include your vending key here"


### PR DESCRIPTION
#### Description
Enhanced the notifications for birthdays:
- In case of only one birthday, show the name and the age
- In case of multiple birthdays:
 - If the notification is collapsed, keep the original behaviour except for the number of events (right bottom of notification) which now displays the number of birthdays
 - If the notification is expanded, show the name of each person and their age

##### Test(s) added
no. Frankly I don't know how I could test this :smile: 

##### Screenshots
In case of only one birthday
![_20160907_204043](https://cloud.githubusercontent.com/assets/2921401/18324706/17993330-753e-11e6-946b-8fab9537b55d.JPG)

In case of multiple birthdays:
**Collapsed**
![screenshot_2016-09-08-10-06-25](https://cloud.githubusercontent.com/assets/2921401/18344462/b420bd76-75b7-11e6-9408-4a46dcfc83e0.png)

**Expanded**
![screenshot_2016-09-08-09-48-41](https://cloud.githubusercontent.com/assets/2921401/18344453/a1633e20-75b7-11e6-80ad-dbeab6462f85.png)

