### PR TITLE
Use only alphanumeric characters for Firebase event names

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/analytics/Action.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/analytics/Action.java
@@ -1,12 +1,12 @@
 package com.alexstyl.specialdates.analytics;
 
 public enum Action {
-    ADD_BIRTHDAY("add birthday"),
-    DAILY_REMINDER("enable daily reminder"),
+    ADD_BIRTHDAY("add_birthday"),
+    DAILY_REMINDER("daily_reminder"),
     DONATION("donate"),
-    INTERACT_CONTACT("interact contact"),
-    SELECT_THEME("select theme"),
-    GO_TO_TODAY("go to today");
+    INTERACT_CONTACT("interact_contact"),
+    SELECT_THEME("select_theme"),
+    GO_TO_TODAY("go_to_today");
 
     private final String name;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/analytics/Action.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/analytics/Action.java
@@ -1,12 +1,12 @@
 package com.alexstyl.specialdates.analytics;
 
 public enum Action {
-    ADD_BIRTHDAY("add_birthday"),
-    DAILY_REMINDER("daily_reminder"),
+    ADD_BIRTHDAY("add_bday"),
+    DAILY_REMINDER("reminder"),
     DONATION("donate"),
-    INTERACT_CONTACT("interact_contact"),
-    SELECT_THEME("select_theme"),
-    GO_TO_TODAY("go_to_today");
+    INTERACT_CONTACT("contact"),
+    SELECT_THEME("theme"),
+    GO_TO_TODAY("gotoday");
 
     private final String name;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/analytics/ActionWithParameters.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/analytics/ActionWithParameters.java
@@ -30,4 +30,12 @@ public final class ActionWithParameters {
         return value;
     }
 
+    @Override
+    public String toString() {
+        return "ActionWithParameters{" +
+                "actionName=" + actionName +
+                ", label='" + label + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
 }

--- a/mobile/src/main/java/com/alexstyl/specialdates/analytics/Firebase.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/analytics/Firebase.java
@@ -48,6 +48,6 @@ public class Firebase implements Analytics {
     }
 
     private String format(ActionWithParameters action) {
-        return String.format(Locale.US, "%s:%s:%s", action.getName(), action.getLabel(), action.getValue());
+        return String.format(Locale.US, "%s_%s_%s", action.getName(), action.getLabel(), action.getValue());
     }
 }

--- a/mobile/src/main/java/com/alexstyl/specialdates/analytics/Firebase.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/analytics/Firebase.java
@@ -47,7 +47,7 @@ public class Firebase implements Analytics {
         Log.d("Tracking screen_view:" + screen);
     }
 
-    private String format(ActionWithParameters action) {
+    static String format(ActionWithParameters action) {
         return String.format(Locale.US, "%s_%s_%s", action.getName(), action.getLabel(), action.getValue());
     }
 }

--- a/mobile/src/test/java/com/alexstyl/specialdates/analytics/FirebaseRulesTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/analytics/FirebaseRulesTest.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static junit.framework.Assert.fail;
 
@@ -13,7 +15,8 @@ import static junit.framework.Assert.fail;
  *
  * @see <a href="https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event">FirebaseAnalytics.Event documentation</a>
  */
-public class FirebaseRulesTest extends MementoTest {
+@RunWith(MockitoJUnitRunner.class)
+public class FirebaseRulesTest {
 
     private final static int MAX_EVENT_NAME_CHAR_COUNT = 32;
     private final static int MAX_EVENTS_COUNT = 500;

--- a/mobile/src/test/java/com/alexstyl/specialdates/analytics/FirebaseRulesTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/analytics/FirebaseRulesTest.java
@@ -1,0 +1,73 @@
+package com.alexstyl.specialdates.analytics;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static junit.framework.Assert.fail;
+
+/**
+ * Class that tests our business logic against all Firebase documentation rules
+ *
+ * @see <a href="https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event">FirebaseAnalytics.Event documentation</a>
+ */
+public class FirebaseRulesTest extends MementoTest {
+
+    private final static int MAX_EVENT_NAME_CHAR_COUNT = 32;
+    private final static int MAX_EVENTS_COUNT = 500;
+
+    @Mock
+    private Analytics mockAnalytics;
+
+    @Test
+    public void actionUpTo32characterlong() {
+        for (Action action : Action.values()) {
+            if (action.getName().length() > MAX_EVENT_NAME_CHAR_COUNT) {
+                failFor(action);
+            }
+        }
+    }
+
+    @Test
+    public void actionWithParamsUpTo32CharacterLong() {
+        List<String> labels = Arrays.asList("enabled", "select", "success", "source");
+        List<String> values = Arrays.asList("true", "false", "success", "external", "sms", "call");
+
+        for (Action action : Action.values()) {
+            for (String label : labels) {
+                for (String value : values) {
+                    ActionWithParameters actionWithParameters = new ActionWithParameters(action, label, value);
+                    String event = Firebase.format(actionWithParameters);
+                    if (event.length() > MAX_EVENT_NAME_CHAR_COUNT) {
+                        failFor(actionWithParameters);
+                    }
+
+                }
+
+            }
+        }
+    }
+
+    @Test
+    public void doesNotExceedNumberOfAllowedEvents() {
+        int numberOfEventsUsed = Action.values().length;
+        if (numberOfEventsUsed > MAX_EVENTS_COUNT) {
+            fail("You can only use up to " + MAX_EVENTS_COUNT + " unique Firebase events. Currently using " + numberOfEventsUsed);
+        }
+
+    }
+
+    private static void failFor(Action action) {
+        int characterCount = action.getName().length();
+        fail(action + " is not a correct action to be used. It contains more than " + MAX_EVENT_NAME_CHAR_COUNT + " characters. Has " + characterCount);
+    }
+
+    private static void failFor(ActionWithParameters action) {
+        int characterCount = Firebase.format(action).length();
+        String message = action + " is not a correct action to be used. It contains more than " + MAX_EVENT_NAME_CHAR_COUNT + " characters. Has " + characterCount;
+        fail(message);
+    }
+
+}

--- a/mobile/src/test/java/com/alexstyl/specialdates/analytics/MementoTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/analytics/MementoTest.java
@@ -1,8 +1,0 @@
-package com.alexstyl.specialdates.analytics;
-
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-@RunWith(MockitoJUnitRunner.class)
-public class MementoTest {
-}

--- a/mobile/src/test/java/com/alexstyl/specialdates/analytics/MementoTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/analytics/MementoTest.java
@@ -1,0 +1,8 @@
+package com.alexstyl.specialdates.analytics;
+
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MementoTest {
+}


### PR DESCRIPTION
#### Description

According to the [FirebaseAnalytics.Event](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event) documentation, the events can only contain alphanumeric characters and must not exceed 32. This check is not done by the framework. This PR "fixes" the names of all events and makes sure that all events are created according to the rules

##### Test(s) added

yes. Around the Rules described in the documentation.