### PR TITLE
Use method Birthday.asDayDate() and use it to ignore year checks

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/contact/Birthday.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/contact/Birthday.java
@@ -65,6 +65,11 @@ public class Birthday implements ShortDate {
         return year - yearOfBirth.get();
     }
 
+    public DayDate asDayDate() {
+        return includesYear() ? DayDate.newInstance(getDayOfMonth(), getMonth(), getYear())
+                : DayDate.newInstance(getDayOfMonth(), getMonth());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/mobile/src/main/java/com/alexstyl/specialdates/date/DateDisplayStringCreator.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/date/DateDisplayStringCreator.java
@@ -60,7 +60,7 @@ public final class DateDisplayStringCreator {
     }
 
     public String fullyFormattedBirthday(Birthday birthday) {
-        DayDate dayDate = DayDate.newInstance(birthday.getDayOfMonth(), birthday.getMonth(), birthday.getYear());
+        DayDate dayDate = birthday.asDayDate();
         Context appContext = MementoApplication.getContext();
 
         int format_flags = DateUtils.FORMAT_NO_NOON_MIDNIGHT | DateUtils.FORMAT_CAP_AMPM | DateUtils.FORMAT_SHOW_DATE;


### PR DESCRIPTION
#### Description

DateDisplayStringCreator tries to get the year of a Birthday without checking if it exists. This PR introduces the `Birthday.asDayDate()` method so that we don't have to check the year if we only care about the day

##### Test(s) added

Unfortunately no. We are using Android specific components to calculate the event