### PR TITLE
Improve UX of Upcoming events list appearance

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
@@ -126,9 +126,7 @@ public class UpcomingEventsFragment extends MementoFragment {
     public void onResume() {
         super.onResume();
         checkIfUserSettingsChanged();
-        if (permissions.permissionIsPresent()) {
-            showData();
-        } else {
+        if (!permissions.permissionIsPresent()) {
             permissions.requestForPermission();
         }
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
@@ -2,6 +2,7 @@ package com.alexstyl.specialdates.upcoming;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.transition.TransitionManager;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -88,7 +89,7 @@ public class UpcomingEventsFragment extends MementoFragment {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_today:
-                onGoToTodayRequested();
+                goToToday();
                 return true;
             default:
                 break;
@@ -96,7 +97,7 @@ public class UpcomingEventsFragment extends MementoFragment {
         return super.onOptionsItemSelected(item);
     }
 
-    private void onGoToTodayRequested() {
+    private void goToToday() {
         analytics.trackAction(Action.GO_TO_TODAY);
         upcomingEventsListView.scrollToToday(true);
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
@@ -163,6 +163,8 @@ public class UpcomingEventsFragment extends MementoFragment {
 
     private void showData() {
         boolean displayingEvents = upcomingEventsListView.isDisplayingEvents();
+
+        TransitionManager.beginDelayedTransition((ViewGroup) upcomingEventsListView.getRootView());
         if (displayingEvents) {
             upcomingEventsListView.setVisibility(View.VISIBLE);
             emptyView.setVisibility(View.GONE);

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/UpcomingEventsListView.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/UpcomingEventsListView.java
@@ -44,31 +44,25 @@ public class UpcomingEventsListView extends RecyclerView {
     }
 
     public void scrollToToday(final boolean smoothScroll) {
-        post(
-                new Runnable() {
-                    public void run() {
-                        int pos = adapter.getClosestDayPosition();
-                        if (pos == RecyclerView.NO_POSITION) {
-                            pos = getLastDayPosition();
-                        }
+        int pos = adapter.getClosestDayPosition();
+        if (pos == RecyclerView.NO_POSITION) {
+            pos = getLastDayPosition();
+        }
 
-                        if (isPositionVisible(pos)) {
-                            onFinishedScrolling(pos);
-                            return;
-                        }
+        if (isPositionVisible(pos)) {
+            onFinishedScrolling(pos);
+            return;
+        }
 
-                        if (smoothScroll) {
-                            smoothScrollTo(pos);
-                        } else {
-                            layoutManager.scrollToPositionWithOffset(pos, 0);
-                        }
-                    }
+        if (smoothScroll) {
+            smoothScrollTo(pos);
+        } else {
+            layoutManager.scrollToPositionWithOffset(pos, 0);
+        }
+    }
 
-                    private int getLastDayPosition() {
-                        return adapter.getItemCount() - 1;
-                    }
-                }
-        );
+    private int getLastDayPosition() {
+        return adapter.getItemCount() - 1;
     }
 
     private void smoothScrollTo(int pos) {

--- a/mobile/src/main/res/layout/fragment_upcoming_events.xml
+++ b/mobile/src/main/res/layout/fragment_upcoming_events.xml
@@ -31,6 +31,6 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:text="@string/no_contacts_text"
-    tools:visibility="gone" />
+    android:visibility="gone" />
 
 </FrameLayout>


### PR DESCRIPTION
#### Description

The upcoming events list was not appearing smoothly when finishing loading. The list would just appear out of the blue and the date would 'jump' to the todays date, instead of just appearing on the specified date. This PR addresses this


##### Screenshots

| Before | After |
| ------ | ----- |
| ![before_ux](https://cloud.githubusercontent.com/assets/1665273/19057721/d7e52d66-89c9-11e6-9b74-2d949a745a25.gif) | ![after_ux](https://cloud.githubusercontent.com/assets/1665273/19057724/de197412-89c9-11e6-9a49-d3d9c32e6d8e.gif) |
