### PR TITLE
Return empty JSON instead of throwing exception

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/calendar/resource/NamedayJSONResourceProvider.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/calendar/resource/NamedayJSONResourceProvider.java
@@ -8,8 +8,9 @@ import org.json.JSONObject;
 
 class NamedayJSONResourceProvider {
 
+    private static final JSONArray EMPTY = new JSONArray();
+
     private final NamedayJSONResourceLoader loader;
-    private final JSONArray jsonArray = new JSONArray();
 
     NamedayJSONResourceProvider(NamedayJSONResourceLoader loader) {
         this.loader = loader;
@@ -26,7 +27,7 @@ class NamedayJSONResourceProvider {
         if (json.has("special")) {
             return json.getJSONArray("special");
         }
-        return jsonArray;
+        return EMPTY;
     }
 
 }

--- a/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/calendar/resource/NamedayJSONResourceProvider.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/events/namedays/calendar/resource/NamedayJSONResourceProvider.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 class NamedayJSONResourceProvider {
 
     private final NamedayJSONResourceLoader loader;
+    private final JSONArray jsonArray = new JSONArray();
 
     NamedayJSONResourceProvider(NamedayJSONResourceLoader loader) {
         this.loader = loader;
@@ -17,8 +18,15 @@ class NamedayJSONResourceProvider {
     NamedayJSON getNamedayJSONFor(NamedayLocale locale) throws JSONException {
         JSONObject json = loader.loadJSON(locale);
         JSONArray data = json.getJSONArray("data");
-        JSONArray special = json.getJSONArray("special");
+        JSONArray special = getSpecialOf(json);
         return new NamedayJSON(data, special);
+    }
+
+    private JSONArray getSpecialOf(JSONObject json) throws JSONException {
+        if (json.has("special")) {
+            return json.getJSONArray("special");
+        }
+        return jsonArray;
     }
 
 }

--- a/mobile/src/test/java/com/alexstyl/specialdates/events/namedays/calendar/resource/NamedayJSONResourceProviderTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/events/namedays/calendar/resource/NamedayJSONResourceProviderTest.java
@@ -17,9 +17,54 @@ public class NamedayJSONResourceProviderTest {
     }
 
     @Test
-    public void namedaysAreNotEmpty() throws Exception {
+    public void allLocalesHaveData() throws Exception {
+        for (NamedayLocale namedayLocale : NamedayLocale.values()) {
+            NamedayJSON namedays = provider.getNamedayJSONFor(namedayLocale);
+            assertThat(namedays.getData().length()).isNotZero();
+        }
+    }
+
+    @Test
+    public void grHasSpecial() throws Exception {
         NamedayJSON namedays = provider.getNamedayJSONFor(NamedayLocale.gr);
-        assertThat(namedays.getData()).isNotNull();
-        assertThat(namedays.getSpecial()).isNotNull();
+        hasSpecial(namedays);
+    }
+
+    @Test
+    public void roHasSpecial() throws Exception {
+        NamedayJSON namedays = provider.getNamedayJSONFor(NamedayLocale.ro);
+        hasSpecial(namedays);
+    }
+
+    @Test
+    public void ruHasNoSpecial() throws Exception {
+        NamedayJSON namedays = provider.getNamedayJSONFor(NamedayLocale.ru);
+        hasNoSpecial(namedays);
+    }
+
+    @Test
+    public void lvHasNoSpecial() throws Exception {
+        NamedayJSON namedays = provider.getNamedayJSONFor(NamedayLocale.lv);
+        hasNoSpecial(namedays);
+    }
+
+    @Test
+    public void csHasNoSpecial() throws Exception {
+        NamedayJSON namedays = provider.getNamedayJSONFor(NamedayLocale.cs);
+        hasNoSpecial(namedays);
+    }
+
+    @Test
+    public void skHasNoSpecial() throws Exception {
+        NamedayJSON namedays = provider.getNamedayJSONFor(NamedayLocale.sk);
+        hasNoSpecial(namedays);
+    }
+
+    private void hasSpecial(NamedayJSON namedays) {
+        assertThat(namedays.getSpecial().length()).isNotZero();
+    }
+
+    private void hasNoSpecial(NamedayJSON namedays) {
+        assertThat(namedays.getSpecial().length()).isZero();
     }
 }


### PR DESCRIPTION
#### Description

This PR checks if the loaded JSON contains the `special` tag before trying to return it. If it doesn't it returns an empty JSONArray instead. 

##### Test(s) added

Added more tests around the nameday JSON resources